### PR TITLE
Include c_src directory within package definition

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Argon2.Mixfile do
   end
 
   defp package do
-    [files: ["lib", "argon2/include", "argon2/src", "mix.exs", "Makefile*", "README.md"],
+    [files: ["lib", "c_src/argon2_nif.c", "argon2/include", "argon2/src", "mix.exs", "Makefile*", "README.md"],
      maintainers: ["David Whitlock"],
      licenses: ["Apache 2.0"],
      links: %{"GitHub" => "https://github.com/riverrun/argon2_elixir",


### PR DESCRIPTION
Hello,

When `{:argon2_elixir, "~> 0.9.0"}` was added in my `deps`, i got this error: 

`No rule to make target 'c_src/argon2_nif.c', needed by 'priv/argon2_nif.so'`

But when it is added as `{:argon2_elixir, git: "https://github.com/riverrun/argon2_elixir.git", submodules: true}` works like a charm in `Archlinux` and `FreeBSD 10.3 STABLE`.

So I added the missing file within package function.

Regards.