### PR TITLE
Fixes "make: Nothing to be done for 'all'."

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ endif
 
 all: $(LIB_NAME)
 
-$(LIB_NAME): $(SRC)
+	$(LIB_NAME): $(SRC)
 	mkdir -p priv
 	$(CC) $(CFLAGS) $(LIB_CFLAGS) $(SO_LDFLAGS) $^ -o $@
 


### PR DESCRIPTION
Without this additional tabulator I got 
```
==> argon2_elixir
make: Nothing to be done for 'all'.
Compiling 3 files (.ex)
Generated argon2_elixir app
```
during compilation, which lead later to `** (UndefinedFunctionError) function Argon2.Base.hash_password/3 is undefined (module Argon2.Base is not available)` runtime.

This fixes it. I had not this problem before, it just happened today, but some of my colleagues had this problem for over a week.

I have no idea if it solves anything, I just read that make can stop compiling with `make: Nothing to be done for 'all'.` if there is no proper indentation if file, like wrong levels of indentation, or mixed spaces and tabs.
