### PR TITLE
Make Comeonin optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ It now has the following two additional convenience functions:
 
 ```elixir
 def deps do
-  [{:argon2_elixir, "~> 2.0"}]
+  [
+    {:argon2_elixir, "~> 2.0"},
+    # Also add this line if you would like to use Comeonin
+    # {:comeonin, "~> 5.3"}
+  ]
 end
 ```
 

--- a/lib/argon2.ex
+++ b/lib/argon2.ex
@@ -43,7 +43,9 @@ defmodule Argon2 do
   to withstand parallel attacks that use GPUs or other dedicated hardware.
   """
 
-  use Comeonin
+  if Code.ensure_loaded?(Comeonin) do
+    use Comeonin
+  end
 
   alias Argon2.Base
 

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Argon2.Mixfile do
 
   defp deps do
     [
-      {:comeonin, "~> 5.3"},
+      {:comeonin, "~> 5.3", optional: true},
       {:elixir_make, "~> 0.6", runtime: false},
       {:ex_doc, "~> 0.23", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0.0", only: :dev, runtime: false}


### PR DESCRIPTION
I am using this library for creating a blind index column in the database and don't need the Comeonin dep so it would be nice to mark that as optional.