### PR TITLE
Change mix.exs licenses field to a valid SPDX identifier

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Argon2.Mixfile do
     [
       files: ["lib", "c_src", "argon2/include", "argon2/src", "mix.exs", "Makefile*", "README.md"],
       maintainers: ["David Whitlock"],
-      licenses: ["Apache 2.0"],
+      licenses: ["Apache-2.0"],
       links: %{"GitHub" => "https://github.com/riverrun/argon2_elixir"}
     ]
   end


### PR DESCRIPTION
Not mandatory, but [recommended](https://hex.pm/docs/publish#adding-metadata-to-code-classinlinemixexscode). Can be useful for a project like https://github.com/Cantido/hex_licenses