### PR TITLE
Bring the example configuration for `config/test.exs` to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,28 @@ password hashing methods.
 
 ## Installation
 
-Add `:argon2_elixir` to your list of dependencies in `mix.exs`:
+1.  Add `:argon2_elixir` to your list of dependencies in `mix.exs`:
 
-```elixir
-def deps do
-  [
-    {:argon2_elixir, "~> 3.0"}
-  ]
-end
-```
+    ```elixir
+    def deps do
+      [
+        {:argon2_elixir, "~> 3.0"}
+      ]
+    end
+    ```
+
+2.  Optional: during tests (and tests only), you may want to speed up the tests. If you have a `config/test.exs`, you can add:
+
+    ```elixir
+    config :argon2_elixir,
+      t_cost: 1,
+      m_cost: 8
+    ```
+
+## Configuration
 
 Configure `argon2_elixir` - see the documentation for
 [`Argon2.Stats`](https://hexdocs.pm/argon2_elixir/Argon2.Stats.html) for more details
-
 
 ## Comeonin wiki
 


### PR DESCRIPTION
## Why

Firstly, to make it similar to the other library like https://github.com/riverrun/pbkdf2_elixir#installation and https://github.com/riverrun/bcrypt_elixir/blob/master/README.md#installation.

Secondly, it will help future developers quickly tweak their `test configuration` right from the README.

## Proof Of Work

<img width="1066" alt="image" src="https://user-images.githubusercontent.com/11751745/191554051-022c5e07-42e3-44d7-a75b-ade7b606fd7d.png">

