### PR TITLE
Support building on illumos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ else
 	ifeq ($(KERNEL_NAME), Darwin)
 		LIB_CFLAGS := -dynamiclib -undefined dynamic_lookup
 	endif
-	ifeq ($(KERNEL_NAME), $(filter $(KERNEL_NAME),OpenBSD FreeBSD NetBSD))
+	ifeq ($(KERNEL_NAME), $(filter $(KERNEL_NAME),OpenBSD FreeBSD NetBSD SunOS))
 		LIB_CFLAGS := -shared -fPIC
 	endif
 endif


### PR DESCRIPTION
While trying to build a program depending on `argon2_elixir` on SmartOS (an illumos distro), I got the following error:

```
==> argon2_elixir
cc -g -O3 -pthread -Wall -Wno-format-truncation -I"/opt/local/lib/erlang/erts-13.1.2/include" -Iargon2/include -Iargon2/src -Ic_src   argon2/src/argon2.c argon2/src/core.c argon2/src/blake2/blake2b.c argon2/src/thread.c argon2/src/encoding.c argon2/src/ref.c c_src/argon2_nif.c -o /<redacted>/_build/prod/lib/argon2_elixir/priv/argon2_nif.so
Undefined                       first referenced
 symbol                             in file
main                                /usr/lib/amd64/crt1.o
enif_get_uint                       /var/tmp//ccRVaI5Q.o
enif_make_tuple                     /var/tmp//ccRVaI5Q.o
enif_get_string                     /var/tmp//ccRVaI5Q.o
enif_make_badarg                    /var/tmp//ccRVaI5Q.o
enif_make_string                    /var/tmp//ccRVaI5Q.o
enif_get_int                        /var/tmp//ccRVaI5Q.o
enif_make_int                       /var/tmp//ccRVaI5Q.o
enif_inspect_binary                 /var/tmp//ccRVaI5Q.o
ld: fatal: symbol referencing errors. No output written to /<redacted>/_build/prod/lib/argon2_elixir/priv/argon2_nif.so
collect2: error: ld returned 1 exit status
make: *** [Makefile:66: /<redacted>/_build/prod/lib/argon2_elixir/priv/argon2_nif.so] Error 1
could not compile dependency :argon2_elixir, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile argon2_elixir", update it with "mix deps.update argon2_elixir" or clean it with "mix deps.clean argon2_elixir"
** (Mix) Could not compile with "make" (exit status: 2).
You need to have gcc and make installed. If you are using
Ubuntu or any other Debian-based system, install the packages
"build-essential". Also install "erlang-dev" package if not
included in your Erlang/OTP version. If you're on Fedora, run
"dnf group install 'Development Tools'".
```

The issue was missing compiler flags, since my kernel name was not one of the supported names in the Makefile. This change simply adds `SunOS` (which is used by both illumos and Solaris) to the Makefile using the same options as the BSDs, which should fix building `argon2_elixir` on most illumos-based distributions.

Verified that it builds without problems on my SmartOS system.