### PR TITLE
Fix compile issues on Windows - related to #59

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -46,7 +46,7 @@ clean:
 	del /Q /F priv
 
 Makefile.auto.win:
-	erl -noshell -s init stop -eval "io:setopts(standard_io, [{encoding, unicode}]), io:format(\"ERTS_INCLUDE_PATH=~ts/erts-~ts/include/\", [code:root_dir(), erlang:system_info(version)])." > $@
+	erl -noshell -eval "io:format(\"ERTS_INCLUDE_PATH=~ts/erts-~ts/include/\", [code:root_dir(), erlang:system_info(version)])." -s init stop > $@
 
 !IFDEF ERTS_INCLUDE_PATH
 priv\argon2_nif.dll:

--- a/test/stats_test.exs
+++ b/test/stats_test.exs
@@ -6,18 +6,18 @@ defmodule Argon2.StatsTest do
 
   test "print report with default options" do
     report = capture_io(fn -> Stats.report() end)
-    assert report =~ "Iterations:\t8\n"
-    assert report =~ "Memory:\t\t64 MiB\n"
-    assert report =~ "Parallelism:\t2\n"
+    assert report =~ ~r/Iterations:\t8(\r)?\n/
+    assert report =~ ~r/Memory:\t\t64 MiB(\r)?\n/
+    assert report =~ ~r/Parallelism:\t2(\r)?\n/
     assert report =~ "Verification OK"
   end
 
   test "use custom options" do
     opts = [t_cost: 4, m_cost: 18, parallelism: 4]
     report = capture_io(fn -> Stats.report(opts) end)
-    assert report =~ "Iterations:\t4\n"
-    assert report =~ "Memory:\t\t256 MiB\n"
-    assert report =~ "Parallelism:\t4\n"
+    assert report =~ ~r/Iterations:\t4(\r)?\n/
+    assert report =~ ~r/Memory:\t\t256 MiB(\r)?\n/
+    assert report =~ ~r/Parallelism:\t4(\r)?\n/
     assert report =~ "Verification OK"
   end
 end


### PR DESCRIPTION
Fixed issue in Makefile.win, which caused an endless loop on Windows and Erlang 26, and made tests in stats_test.exs run on Windows too.