### PR TITLE
chore(Elixir): Fix charlist warning in elixir 1.17

### DIFF
--- a/lib/argon2/base.ex
+++ b/lib/argon2/base.ex
@@ -127,7 +127,7 @@ defmodule Argon2.Base do
   end
 
   defp load_nif do
-    path = :filename.join(:code.priv_dir(:argon2_elixir), 'argon2_nif')
+    path = :filename.join(:code.priv_dir(:argon2_elixir), "argon2_nif")
     :erlang.load_nif(path, 0)
   end
 


### PR DESCRIPTION
@riverrun Elixir emits a warning for charlists not declared using the `~c""` sigil in version 1.17.0. Looking up the docs for erlang's filename module it looks like strings are the preferred method for joining paths.

https://www.erlang.org/doc/apps/stdlib/filename.html#join/1