### PR TITLE
Argon2.Base: Use sigil_c/2 for charlist to fix warning

### DIFF
--- a/lib/argon2/base.ex
+++ b/lib/argon2/base.ex
@@ -127,7 +127,7 @@ defmodule Argon2.Base do
   end
 
   defp load_nif do
-    path = :filename.join(:code.priv_dir(:argon2_elixir), 'argon2_nif')
+    path = :filename.join(:code.priv_dir(:argon2_elixir), ~c"argon2_nif")
     :erlang.load_nif(path, 0)
   end
 


### PR DESCRIPTION
Supported since Elixir 1.0