### PR TITLE
compilation warning with elixir 1.18

### DIFF
--- a/lib/argon2.ex
+++ b/lib/argon2.ex
@@ -90,7 +90,7 @@ defmodule Argon2 do
     case Base.verify_nif(hash, password, argon2_type(stored_hash)) do
       0 -> true
       -35 -> false
-      error -> raise ArgumentError, Base.handle_error(error)
+      error -> Base.handle_error(error)
     end
   end
 


### PR DESCRIPTION
the upcoming elixir 1.18 will emit the following warning when compiling

```
warning: incompatible types given to ArgumentError.exception/1:

        ArgumentError.exception(Argon2.Base.handle_error(error))

    given types:

        none()

    the 1st argument is empty (often represented as none()), most likely because it is the result of an expression that always fails, such as a `raise` or a previous invalid call. This causes any function called with this value to fail

    where "error" was given the type:

        # type: dynamic()
        # from: lib/argon2.ex:93:7
        error

    typing violation found at:
    │
 93 │       error -> raise ArgumentError, Base.handle_error(error)
    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    │
    └─ lib/argon2.ex:93: Argon2.verify_pass/2
```

this is due to the `raise ArgumentError` at line 93 never being actually called, since it's argument (the call to `Base.handle_error/1`) already raises an `ArgumentError` exception
